### PR TITLE
Make abstract optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ typst init @preview/clean-math-paper:0.1.0
 - `date`: Date of the paper.
 - `heading-color`: Color of the headings including the title.
 - `link-color`: Color of the links.
-- `abstract`: Abstract of the paper.
+- `abstract`: Abstract of the paper. If not provided, nothing will be shown.
 - `keywords`: List of keywords of the paper. If not provided, nothing will be shown.
 - `AMS`: List of AMS subject classifications of the paper. If not provided, nothing will be shown.
 

--- a/lib.typ
+++ b/lib.typ
@@ -78,7 +78,7 @@
   authors: (),
   affiliations: (),
   date: datetime.today().display(),
-  abstract: [],
+  abstract: none,
   keywords: (),
   AMS: (),
   heading-color: rgb("#000000"),
@@ -180,28 +180,30 @@
   align(center)[#date]
 
   // Abstract.
-  pad(
-    x: 3em,
-    top: 1em,
-    bottom: 0.4em,
-    align(center)[
-      #heading(
-        outlined: false,
-        numbering: none,
-        text(0.85em, smallcaps[Abstract]),
-      )
-      #set par(justify: true)
-      #set text(hyphenate: false)
+  if abstract != none {
+    pad(
+      x: 3em,
+      top: 1em,
+      bottom: 0.4em,
+      align(center)[
+        #heading(
+          outlined: false,
+          numbering: none,
+          text(0.85em, smallcaps[Abstract]),
+        )
+        #set par(justify: true)
+        #set text(hyphenate: false)
 
-      #abstract
-    ],
-  )
+        #abstract
+      ],
+    )
+  }
 
   // Keywords
   if keywords.len() > 0 {
       [*_Keywords_*. #h(0.3cm)] + keywords.map(str).join(" · ")
+      linebreak()
   }
-  linebreak()
   // AMS
   if AMS.len() > 0 {
       [*AMS subject classification*. #h(0.3cm)] + AMS.map(str).join(", ")


### PR DESCRIPTION
Only show the abstract if the keyword is not `none` (new default). Closes #1.