### PR TITLE
Create translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ typst init @preview/clean-math-paper:0.2.0
 - `abstract`: Abstract of the paper. If not provided, nothing will be shown.
 - `keywords`: List of keywords of the paper. If not provided, nothing will be shown.
 - `AMS`: List of AMS subject classifications of the paper. If not provided, nothing will be shown.
-- `lang`: Language of the paper. Supported languages are English, German, French and Spanish, default is "en".
-- `translations`: Dictionary to override the language translations. Please refer to the `Support for languages` section for more informations.
+- `lang`: Language of the paper. Supported languages are English, German, French, and Spanish, default is "en".
+- `translations`: Dictionary to override the language translations. Please refer to the `Support for languages` section for more information.
 - `heading-color`: Color of the headings including the title.
 - `link-color`: Color of the links.
 
@@ -56,7 +56,7 @@ where `my-mathblock` already includes the counter shared between mathblocks. You
 
 ### Support for languages
 
-This template includes translations for English, German, French and Spanish. To use one of these languages, set the lang parameter to `en`, `de`, `fr` or `es`:
+This template includes translations for English, German, French, and Spanish. To use one of these languages, set the lang parameter to `en`, `de`, `fr`, or `es`:
 
 ```typst
 #show: template.with(
@@ -65,8 +65,10 @@ This template includes translations for English, German, French and Spanish. To 
 ```
 
 For languages not included by default, or to override existing translations:
+
 - set `lang` to your language's ISO code (see [Typst docs](https://typst.app/docs/reference/text/text/#parameters-lang))
-- provide a `translations` dictionnary with your custom translations, like below
+- provide a `translations` dictionary with your custom translations, like below
+
 ```typst
 #show: template.with(
   lang: "en",
@@ -89,6 +91,7 @@ For languages not included by default, or to override existing translations:
 ```
 
 You can also register a new language with `add-language`.
+
 ```typst
 #add-language("en", (
   "theorem": "Theorem",
@@ -96,8 +99,7 @@ You can also register a new language with `add-language`.
 ))
 ```
 
-To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys with be overriden.
-
+To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys will be overridden.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can also register a new language with `add-language`.
 ))
 ```
 
-To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys will be overridden.
+To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys will be overridden. Note that you need to call `add-language` before the `#show: template.with(...)` call, otherwise the translations might not be applied.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -90,16 +90,7 @@ For languages not included by default, or to override existing translations:
 )
 ```
 
-You can also register a new language with `add-language`.
-
-```typst
-#add-language("en", (
-  "theorem": "Theorem",
-  // ...
-))
-```
-
-To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys will be overridden. Note that you need to call `add-language` before the `#show: template.with(...)` call, otherwise the translations might not be applied.
+To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys will be overridden.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ typst init @preview/clean-math-paper:0.2.0
 - `abstract`: Abstract of the paper. If not provided, nothing will be shown.
 - `keywords`: List of keywords of the paper. If not provided, nothing will be shown.
 - `AMS`: List of AMS subject classifications of the paper. If not provided, nothing will be shown.
-- `lang`: Language of the paper. Supported languages are English, German, and French, default is "en".
+- `lang`: Language of the paper. Supported languages are English, German, French and Spanish, default is "en".
+- `translations`: Dictionary to override the language translations. Please refer to the `Support for languages` section for more informations.
 - `heading-color`: Color of the headings including the title.
 - `link-color`: Color of the links.
 
@@ -52,6 +53,51 @@ This template uses the [great-theorems](https://typst.app/universe/package/great
 ```
 
 where `my-mathblock` already includes the counter shared between mathblocks. You can also directly use `mathblock` instead if you do not want to use the default setting used in this template.
+
+### Support for languages
+
+This template includes translations for English, German, French and Spanish. To use one of these languages, set the lang parameter to `en`, `de`, `fr` or `es`:
+
+```typst
+#show: template.with(
+  lang: "en"
+)
+```
+
+For languages not included by default, or to override existing translations:
+- set `lang` to your language's ISO code (see [Typst docs](https://typst.app/docs/reference/text/text/#parameters-lang))
+- provide a `translations` dictionnary with your custom translations, like below
+```typst
+#show: template.with(
+  lang: "en",
+  translations: (
+    "theorem": "Theorem",
+    "proposition": "Proposition",
+    "corollary": "Corollary",
+    "lemma": "Lemma",
+    "definition": "Definition",
+    "remark": "Remark",
+    "example": "Example",
+    "question": "Question",
+    "proof": "Proof",
+    "keywords": "Keywords",
+    "ams": "AMS subject classification",
+    "appendix": "Appendix",
+    "abstract": "Abstract",
+  )
+)
+```
+
+You can also register a new language with `add-language`.
+```typst
+#add-language("en", (
+  "theorem": "Theorem",
+  // ...
+))
+```
+
+To modify specific translations for a supported language, a partial dictionary is enough. Only the specified keys with be overriden.
+
 
 ## Acknowledgements
 

--- a/lib.typ
+++ b/lib.typ
@@ -3,63 +3,78 @@
 #import "@preview/i-figured:0.2.4": reset-counters, show-equation
 
 // Language support
-#let language-translations = (
-  en: (
-    "theorem": "Theorem",
-    "proposition": "Proposition",
-    "corollary": "Corollary",
-    "lemma": "Lemma",
-    "definition": "Definition",
-    "remark": "Remark",
-    "example": "Example",
-    "question": "Question",
-    "proof": "Proof",
-    "keywords": "Keywords",
-    "ams": "AMS subject classification",
-    "appendix": "Appendix",
-    "abstract": "Abstract",
-  ),
-  de: (
-    "theorem": "Satz",
-    "proposition": "Proposition",
-    "corollary": "Korollar",
-    "lemma": "Lemma",
-    "definition": "Definition",
-    "remark": "Anmerkung",
-    "example": "Beispiel",
-    "question": "Frage",
-    "proof": "Beweis",
-    "keywords": "Schlüsselwörter",
-    "ams": "AMS-Klassifikation",
-    "appendix": "Anhang",
-    "abstract": "Zusammenfassung",
-  ),
-  fr: (
-    "theorem": "Théorème",
-    "proposition": "Proposition",
-    "corollary": "Corollaire",
-    "lemma": "Lemme",
-    "definition": "Définition",
-    "remark": "Remarque",
-    "example": "Exemple",
-    "question": "Question",
-    "proof": "Preuve",
-    "keywords": "Mots clés",
-    "ams": "Classification AMS",
-    "appendix": "Annexe",
-    "abstract": "Résumé",
+#let language-translations = state(
+  "language-translations",
+  (
+    en: (
+      "theorem": "Theorem",
+      "proposition": "Proposition",
+      "corollary": "Corollary",
+      "lemma": "Lemma",
+      "definition": "Definition",
+      "remark": "Remark",
+      "example": "Example",
+      "question": "Question",
+      "proof": "Proof",
+      "keywords": "Keywords",
+      "ams": "AMS subject classification",
+      "appendix": "Appendix",
+      "abstract": "Abstract",
+    ),
+    de: (
+      "theorem": "Satz",
+      "proposition": "Proposition",
+      "corollary": "Korollar",
+      "lemma": "Lemma",
+      "definition": "Definition",
+      "remark": "Anmerkung",
+      "example": "Beispiel",
+      "question": "Frage",
+      "proof": "Beweis",
+      "keywords": "Schlüsselwörter",
+      "ams": "AMS-Klassifikation",
+      "appendix": "Anhang",
+      "abstract": "Zusammenfassung",
+    ),
+    fr: (
+      "theorem": "Théorème",
+      "proposition": "Proposition",
+      "corollary": "Corollaire",
+      "lemma": "Lemme",
+      "definition": "Définition",
+      "remark": "Remarque",
+      "example": "Exemple",
+      "question": "Question",
+      "proof": "Preuve",
+      "keywords": "Mots clés",
+      "ams": "Classification AMS",
+      "appendix": "Annexe",
+      "abstract": "Résumé",
+    ),
   ),
 )
 
 #let get-language-title(label) = {
   context {
     let language = str(text.lang)
-    if language in language-translations {
-      return language-translations.at(language).at(label, default: "Unknown")
+    let translations = language-translations.get()
+    if language in translations {
+      translations.at(language).at(label, default: "Unknown")
     } else {
-      return language-translations.en.at(label, default: "Unknown")
+      translations.en.at(label, default: "Unknown")
     }
   }
+}
+
+#let add-language(lang, translations) = {
+  language-translations.update(value => {
+    if lang in value {
+      value.insert(lang, value.at(lang) + translations)
+    } else {
+      value.insert(lang, translations)
+    }
+    value
+  })
 }
 
 // counter for mathblocks
@@ -136,6 +151,7 @@
   keywords: (),
   AMS: (),
   lang: "en",
+  translations: none,
   heading-color: rgb("#000000"),
   link-color: rgb("#000000"),
   body,
@@ -153,6 +169,11 @@
   set enum(numbering: "(i)")
   set outline(indent: 2em) // indent: auto does not work well with appendices
   show: great-theorems-init
+
+  // Overrides the current translations
+  if lang != none and translations != none {
+    add-language(lang, translations)
+  }
 
   // table label on top and not below the table
   show figure.where(kind: table): set figure.caption(position: top)

--- a/lib.typ
+++ b/lib.typ
@@ -81,17 +81,6 @@
   }
 }
 
-#let add-language(lang, translations) = {
-  language-translations.update(value => {
-    if lang in value {
-      value.insert(lang, value.at(lang) + translations)
-    } else {
-      value.insert(lang, translations)
-    }
-    value
-  })
-}
-
 // counter for mathblocks
 #let theoremcounter = rich-counter(
   identifier: "mathblocks",
@@ -187,7 +176,14 @@
 
   // Overrides the current translations
   if lang != none and translations != none {
-    add-language(lang, translations)
+    language-translations.update(value => {
+      if lang in value {
+        value.insert(lang, value.at(lang) + translations)
+      } else {
+        value.insert(lang, translations)
+      }
+      value
+    })
   }
 
   // table label on top and not below the table

--- a/lib.typ
+++ b/lib.typ
@@ -51,6 +51,21 @@
       "appendix": "Annexe",
       "abstract": "Résumé",
     ),
+    es: (
+      "theorem": "Teorema",
+      "proposition": "Proposición",
+      "corollary": "Corolario",
+      "lemma": "Lema",
+      "definition": "Definición",
+      "remark": "Comentario",
+      "example": "Ejemplo",
+      "question": "Pregunta",
+      "proof": "Demostración",
+      "keywords": "Palabras clave",
+      "ams": "Clasificación AMS",
+      "appendix": "Apéndice",
+      "abstract": "Resumen",
+    ),
   ),
 )
 


### PR DESCRIPTION
The following changes have been made:
- the language-translations dictionary is now in a state
- the add-language function can add new languages. If the language exists, modified fields are updated, otherwise the new translations are added.
- a translations argument has been added to the template function, in order to override the translations for the selected language