### PR TITLE
Allow to change `page` arguments

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -146,6 +146,12 @@
   }
 }
 
+#let default-page-args = (
+  margin: (left: 25mm, right: 25mm, top: 25mm, bottom: 30mm),
+  numbering: "1",
+  number-align: center,
+)
+
 #let template(
   title: "",
   authors: (),
@@ -159,15 +165,12 @@
   heading-color: rgb("#000000"),
   link-color: rgb("#000000"),
   lines: true,
+  page-args: default-page-args,
   body,
 ) = {
   // Set the document's basic properties.
   set document(author: authors.map(a => a.name), title: title)
-  set page(
-    margin: (left: 25mm, right: 25mm, top: 25mm, bottom: 30mm),
-    numbering: "1",
-    number-align: center,
-  )
+  set page(..page-args)
   set text(font: "New Computer Modern", lang: lang)
   set enum(numbering: "(i)")
   set outline(indent: 2em) // indent: auto does not work well with appendices

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,6 +1,10 @@
-#import "@preview/clean-math-paper:0.2.3": *
+#import "@local/clean-math-paper:0.2.3": *
 
 #let date = datetime.today().display("[month repr:long] [day], [year]")
+
+// Modify page args, which can be overwritten in the template call
+#default-page-args.insert("numbering", "1/1")
+
 #show: template.with(
   title: "Typst template for mathematical papers",
   authors: (
@@ -19,7 +23,8 @@
   // Example: `abstract: [This is my abstract...]`
   abstract: lorem(30),
   keywords: ("First keyword", "Second keyword", "etc."),
-  AMS: ("65M70", "65M12")
+  AMS: ("65M70", "65M12"),
+  // page-args: default-page-args,
 )
 
 = Introduction

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,4 @@
-#import "@local/clean-math-paper:0.2.3": *
+#import "../lib.typ": *
 
 #let date = datetime.today().display("[month repr:long] [day], [year]")
 


### PR DESCRIPTION
Can be used to modify the arguments to `page` as requested in #17.
Closes #17.