### PR TITLE
Add options controlling equation boxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ typst init @preview/clean-math-paper:0.2.5
 - `page-args`: Dictionary to set page arguments, e.g., to change the number of columns or page numbering. See [Typst docs](https://typst.app/docs/reference/layout/page/) for more information. The default page arguments can be accessed via `page-args`, i.e., if you want to change only some of the default settings, you can use `insert` on `page-args` to change specific settings.
 - `text-args-title`: Dictionary to set text arguments for the title, e.g., to change the font size or color. See [Typst docs](https://typst.app/docs/reference/text/text/) for more information. The default arguments can be accessed via `text-args-title`, i.e., if you want to change only some of the default settings, you can use `insert` on `text-args-title` to change specific settings.
 - `text-args-authors`: Dictionary to set text arguments for the authors' names, e.g., to change the font weight or style. See [Typst docs](https://typst.app/docs/reference/text/text/) for more information. The default arguments can be accessed via `text-args-authors`, i.e., if you want to change only some of the default settings, you can use `insert` on `text-args-authors` to change specific settings.
+- `equation-box-inline`: Whether inline equations are wrapped in boxes. Default is `true`.
+- `equation-box-block`: Whether block equations are wrapped in boxes. Default is `false`.
 
 ### Support for mathblocks
 

--- a/lib.typ
+++ b/lib.typ
@@ -171,6 +171,8 @@
   text-args-title: text-args-title,
   text-args-authors: text-args-authors,
   ncolumns: 1,
+  equation-box-inline: true,
+  equation-box-block: false,
   body,
 ) = {
   // Set the document's basic properties.
@@ -209,8 +211,23 @@
   // Using headcount:
   // show heading: reset-counter(counter(math.equation))
   // set math.equation(numbering: dependent-numbering("(1.1)"))
+  //
   set math.equation(supplement: none)
-  show math.equation: box // no line breaks in inline math
+
+  show math.equation.where(block: false): x => {
+    if equation-box-inline {
+      box(x) // no line breaks in inline math
+    } else {
+      x
+    }
+  }
+  show math.equation.where(block: true): x => {
+    if equation-box-block {
+      box(x)
+    } else {
+      x
+    }
+  }
 
   if lines {
     line(length: 100%, stroke: 2pt)

--- a/lib.typ
+++ b/lib.typ
@@ -211,7 +211,6 @@
   // Using headcount:
   // show heading: reset-counter(counter(math.equation))
   // set math.equation(numbering: dependent-numbering("(1.1)"))
-  //
   set math.equation(supplement: none)
 
   show math.equation.where(block: false): x => {


### PR DESCRIPTION
Add options `equation-box-inline` and `equation-box-block` to control whether inline and block equations are boxed. Now block equations are no longer boxed by default.

This fixes the issue that block equations cannot span multiple pages.